### PR TITLE
Allow more whitespace between 2DA and version

### DIFF
--- a/grammars/2da.cson
+++ b/grammars/2da.cson
@@ -8,8 +8,8 @@ patterns: [{
 	# Lines 1-2: 2DA version + optional default value
 	name:  "meta.header.2da"
 	begin: """(?x) \\A
-		[ \\t]* (2DA\\ V(?:\\d+\\.\\d+)) # Format signature
-		[ \\t]* (?:(\\S.*?) [ \\t]*)?    # Unexpected junk
+		[ \\t]* (2DA\\s+V(?:\\d+\\.\\d+)) # Format signature
+		[ \\t]* (?:(\\S.*?) [ \\t]*)?     # Unexpected junk
 		$ \\s*
 	"""
 	end: "(?!\\G)$"

--- a/grammars/2da.cson
+++ b/grammars/2da.cson
@@ -1,7 +1,7 @@
 name: "2-Dimensional Array"
 scopeName: "source.2da"
 fileTypes: ["2da"]
-firstLineMatch: "^[ \\t]*2DA V[12]\\.0[ \\t]*$"
+firstLineMatch: "^[ \\t]*2DA\\s+V[12]\\.0[ \\t]*$"
 limitLineLength: no
 maxTokensPerLine: 2048
 patterns: [{


### PR DESCRIPTION
I noticed that in some cases 2DA files include a larger amount of whitespace than one space character so I wanted to include that. Feel free to close if you don't think it's necessary.﻿
