### PR TITLE
Attempting to add colours to Hosts IPs

### DIFF
--- a/grammars/hosts.cson
+++ b/grammars/hosts.cson
@@ -10,6 +10,7 @@ repository:
 			{include: "etc#ip"}
 			{include: "#loopback"}
 			{include: "#host"}
+			{include: "#ip"}
 		]
 	
 	# Compressed form of IPv6's loopback address
@@ -25,3 +26,10 @@ repository:
 		match: "(?<=\\s|^)[^:\\s#][^\\s#]*"
 		captures:
 			0: patterns: [include: "etc#dot"]
+
+	# Marking IP addresses with the "keyword" GitHub CSS color
+	ip:
+		name: "keyword.numeric.host.ip.hosts"
+		match: "^(((\d\d?|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d\d?|1\d\d|2[0-4]\d|25[0-5])|([0-9a-f]{1,})?:([0-9a-f]{1,})?:([0-9a-f:]{1,29})?)\s"
+		captures:
+			1: name: "keyword.control.ip"


### PR DESCRIPTION
After I figured out from studying various syntaxes this morning that there was likely a connection between `name: keyword.(...)` in Linguist files and `--color-prettylights-syntax-keyword` in Dev Tools element styles on GitHub, I figured I should give this a fair try.

If this works, I could plausibly also attempt to add `name: "invalid.illegal"` to incorrect syntaxes (e.g. `691.82.319.7`, `*`) at a later time.